### PR TITLE
Add Clear Completed button to Active Requests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r api/requirements.txt
+pytest==8.3.5
+pytest-asyncio==0.25.3

--- a/web/app.js
+++ b/web/app.js
@@ -515,6 +515,19 @@ async function toggleQueuePause() {
   }
 }
 
+async function clearCompletedRequests() {
+  try {
+    const r = await post("/api/merllm/queue/clear", {});
+    const n = (r.removed?.completed || 0) + (r.removed?.failed || 0);
+    if (n === 0) {
+      alert("No completed or failed requests to clear.");
+    }
+    loadQueue();
+  } catch (err) {
+    alert("Clear failed: " + err.message);
+  }
+}
+
 function _gpuLabel(url) {
   if (!url) return "—";
   if (url.includes("11434")) return "GPU 0";

--- a/web/index.html
+++ b/web/index.html
@@ -114,6 +114,7 @@
       <h2>Active Requests
         <span id="queue-pause-controls" style="float:right;display:flex;gap:6px;align-items:center">
           <button id="queue-pause-btn" class="btn" style="padding:2px 10px;font-size:11px" onclick="toggleQueuePause()">Pause Queue</button>
+          <button class="btn" style="padding:2px 10px;font-size:11px" onclick="clearCompletedRequests()">Clear Completed</button>
           <button class="btn" style="padding:2px 10px;font-size:11px" onclick="loadQueue()">Refresh</button>
         </span>
       </h2>


### PR DESCRIPTION
Closes #45

Adds a "Clear Completed" button to the Active Requests card header, alongside the existing Pause and Refresh buttons. Clicking it calls `POST /api/merllm/queue/clear` (which already existed but was not exposed in the UI) to remove completed and failed entries from the in-memory queue tracker. The table refreshes automatically afterward.

**Tests:** 161 passed (stress/integration suites excluded — they hang due to pre-existing timeout issues unrelated to this change).

**Visual verification pending — automated agent. Manual browser check required before merge.**