### PR TITLE
Fix CI Tests workflow (env leak + unmarked integration suite)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
         run: pip install --no-cache-dir -r requirements-dev.txt
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short -m "not stress"
+        run: pytest tests/ -v --tb=short -m "not stress and not integration"
         env:
           DB_PATH: ":memory:"
-          OLLAMA_0_URL: "http://localhost:11434"
-          OLLAMA_1_URL: "http://localhost:11435"

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ testpaths = tests
 asyncio_mode = auto
 markers =
     stress: slow stress/performance tests (run manually or on schedule)
+    integration: cross-service integration tests requiring live lancellmot/merllm/parsival

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r api/requirements.txt
+pytest==8.3.5
+pytest-asyncio==0.25.3

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,6 +19,8 @@ import uuid
 import pytest
 import httpx
 
+pytestmark = pytest.mark.integration
+
 LANCELLMOT = "http://localhost:8080"
 MERLLM     = "http://localhost:11400"
 PARSIVAL   = "http://localhost:8082"


### PR DESCRIPTION
Closes #48

## Summary
- Register an `integration` marker in `pytest.ini`
- Mark `tests/test_integration.py` with `pytestmark = pytest.mark.integration`
- Drop `OLLAMA_0_URL`/`OLLAMA_1_URL` env vars from the Tests workflow (they only mattered for integration tests, which can't run in CI)
- Update the workflow's pytest filter to `-m "not stress and not integration"`

## Verification
Locally, with the exact workflow command:

```
unset OLLAMA_0_URL OLLAMA_1_URL
DB_PATH=:memory: pytest tests/ -v --tb=short -m "not stress and not integration"
```

→ **161 passed, 71 deselected** (vs. 59 failures on `main` when deps install).

## Why this matters
CI had been green on main only because `pip install -r requirements-dev.txt` errored before any test ran (the file was never committed). With that fixed on PR #47's branch, the real test failures surfaced — all of them environmental/marker gaps, none related to the code under review. This patch restores CI as a trustworthy merge gate.