### PR TITLE
Fix upload 500 race: warm embedding models on correct Ollama endpoint

### DIFF
--- a/api/gpu_router.py
+++ b/api/gpu_router.py
@@ -238,8 +238,22 @@ async def reclaim_loop() -> None:
                 log.info("DEFAULT_MODEL change complete")
 
 
-async def _reload_model(gpu: GpuState, model: str) -> None:
+async def _reload_model(gpu: GpuState, model: str) -> bool:
     """Send a warmup request to load a model on a GPU.
+
+    Ollama's ``/api/generate`` endpoint rejects embedding-only models with
+    HTTP 400 (``"<model>" does not support generate``). Warming those via
+    ``/api/generate`` would silently no-op — Ollama returns an error body
+    but does not load the model. The dispatcher would then hand off a
+    request to a GPU whose real load happens on the first ``/api/embeddings``
+    call, and any concurrent embedding traffic during that load races and
+    gets 500s. So we branch on the model name and use ``/api/embed`` for
+    anything with "embed" in it (nomic-embed-text, mxbai-embed-large, etc.).
+
+    ``resp.raise_for_status()`` makes a non-2xx warmup a hard failure:
+    ``gpu.model`` is only updated once the warmup actually succeeded, so
+    the reclaim loop will retry on its next tick instead of believing a
+    swap landed when it didn't. Returns True on success, False on failure.
 
     For large reasoning models we pin ``num_ctx`` so Ollama does not
     auto-fit the context window to the model's training maximum on a
@@ -251,16 +265,24 @@ async def _reload_model(gpu: GpuState, model: str) -> None:
     ``queue_manager._run_batch_job_async`` and the
     ``feedback_reasoning_model_caps`` rule.
     """
-    body: dict = {"model": model, "prompt": "", "keep_alive": "10m"}
-    if model.startswith("qwen3:"):
-        body["options"] = {"num_ctx": 8192}
+    if "embed" in model:
+        path = "/api/embed"
+        body: dict = {"model": model, "input": "x", "keep_alive": "10m"}
+    else:
+        path = "/api/generate"
+        body = {"model": model, "prompt": "", "keep_alive": "10m"}
+        if model.startswith("qwen3:"):
+            body["options"] = {"num_ctx": 8192}
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(120.0)) as client:
-            await client.post(f"{gpu.url}/api/generate", json=body)
+            resp = await client.post(f"{gpu.url}{path}", json=body)
+            resp.raise_for_status()
         gpu.model = model
         log.info("GPU %s reloaded with %r", gpu.url, model)
+        return True
     except Exception as exc:
         log.warning("failed to reload %r on GPU %s: %s", model, gpu.url, exc)
+        return False
 
 
 async def _probe_gpu(gpu: GpuState, now: float) -> None:

--- a/api/queue_manager.py
+++ b/api/queue_manager.py
@@ -756,8 +756,20 @@ async def _dispatch(req: _PendingRequest, target: str) -> None:
                 req.tid[:8], target[-5:], gpu_state.model, req.model,
             )
             swap_start = time.time()
-            await gpu_router._reload_model(gpu_state, req.model)
+            ok = await gpu_router._reload_model(gpu_state, req.model)
             swap_ms = (time.time() - swap_start) * 1000
+            if not ok:
+                # Warmup POST did not land: Ollama returned non-2xx, the
+                # connection failed, or the wrong endpoint was used. Do
+                # not hand off — the model is not actually loaded and
+                # the proxy call would 500 on the real request.
+                dispatch_log.warning(
+                    "[dispatch] swap failed tid=%s gpu=%s target=%r ms=%.0f",
+                    req.tid[:8], target[-5:], req.model, swap_ms,
+                )
+                raise RuntimeError(
+                    f"failed to load model {req.model!r} on GPU {target}"
+                )
             dispatch_log.info(
                 "[dispatch] swap done tid=%s gpu=%s ms=%.0f",
                 req.tid[:8], target[-5:], swap_ms,

--- a/tests/test_gpu_router.py
+++ b/tests/test_gpu_router.py
@@ -11,6 +11,7 @@ import sys
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "api"))
@@ -191,20 +192,79 @@ async def test_reload_model_pins_num_ctx_for_qwen3():
 
 
 @pytest.mark.asyncio
-async def test_reload_model_omits_options_for_non_qwen3():
-    """Non-qwen3 reloads must not inject num_ctx — only the known-large
-    reasoning models need pinning."""
+async def test_reload_model_omits_options_for_non_qwen3_generative():
+    """Non-qwen3 generative reloads must not inject num_ctx — only the
+    known-large reasoning models need pinning."""
     router, config = _get_router()
     gpu = router._gpus[config.OLLAMA_0_URL]
 
     mock_client, captured = _make_post_capturing_client()
     with patch("gpu_router.httpx.AsyncClient", return_value=mock_client):
-        await router._reload_model(gpu, "nomic-embed-text")
+        ok = await router._reload_model(gpu, "llama3.1:8b")
 
+    assert ok is True
+    assert captured["url"].endswith("/api/generate")
+    body = captured["kwargs"]["json"]
+    assert body["model"] == "llama3.1:8b"
+    assert "options" not in body
+    assert gpu.model == "llama3.1:8b"
+
+
+@pytest.mark.asyncio
+async def test_reload_model_uses_embed_endpoint_for_embedding_models():
+    """Embedding models must warm via /api/embed, not /api/generate.
+
+    Regression: 2026-04-14 upload 500 race. Ollama's /api/generate returns
+    HTTP 400 for embedding-only models, so warming via /api/generate never
+    actually loads the model. The dispatcher would then hand requests off
+    to a GPU whose real load happens on the first /api/embeddings call,
+    and concurrent traffic during that load races and 500s.
+    """
+    router, config = _get_router()
+    gpu = router._gpus[config.OLLAMA_0_URL]
+
+    mock_client, captured = _make_post_capturing_client()
+    with patch("gpu_router.httpx.AsyncClient", return_value=mock_client):
+        ok = await router._reload_model(gpu, "nomic-embed-text")
+
+    assert ok is True
+    assert captured["url"].endswith("/api/embed")
     body = captured["kwargs"]["json"]
     assert body["model"] == "nomic-embed-text"
-    assert "options" not in body
+    assert "input" in body and body["input"]
+    assert "prompt" not in body
     assert gpu.model == "nomic-embed-text"
+
+
+@pytest.mark.asyncio
+async def test_reload_model_returns_false_and_preserves_model_on_http_error():
+    """A non-2xx warmup must leave gpu.model untouched and return False,
+    so the dispatcher / reclaim loop can decide whether to retry instead
+    of believing a swap landed when it didn't."""
+    router, config = _get_router()
+    gpu = router._gpus[config.OLLAMA_0_URL]
+    original_model = gpu.model
+
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+    )
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    async def _post(url, **kwargs):
+        return mock_resp
+    mock_client.post = _post
+
+    with patch("gpu_router.httpx.AsyncClient", return_value=mock_client):
+        ok = await router._reload_model(gpu, "qwen3:32b")
+
+    assert ok is False
+    assert gpu.model == original_model
 
 
 # ── Thermal pause tests ──────────────────────────────────────────────────────

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -60,6 +60,7 @@ def patch_reload(monkeypatch):
 
     async def _noop_reload(gpu, model):
         gpu.model = model
+        return True
 
     monkeypatch.setattr(gpu_router, "_reload_model", _noop_reload)
 
@@ -391,6 +392,7 @@ async def test_interactive_dispatch_timeout(monkeypatch):
 
     async def _noop_reload(gpu, model):
         gpu.model = model
+        return True
     monkeypatch.setattr(gpu_router, "_reload_model", _noop_reload)
 
     # Saturate both GPUs via the reclaim-loop reservation hook so the
@@ -587,6 +589,29 @@ async def test_dispatcher_swaps_when_no_affinity(qm, patch_reload):
     qm.release(tid)
 
 
+@pytest.mark.asyncio
+async def test_dispatcher_fails_request_when_reload_fails(qm, monkeypatch):
+    """If _reload_model returns False, the dispatcher must fail the request
+    rather than hand it off to a GPU whose model did not actually load.
+
+    Regression: 2026-04-14 upload 500 race. _reload_model used to silently
+    claim success for embedding models (wrong endpoint), and the dispatcher
+    would trust it and proxy to an unloaded GPU, where concurrent requests
+    raced on the real load and Ollama 500'd.
+    """
+    import gpu_router
+    gpu_router._init_gpus()
+
+    async def _failing_reload(gpu, model):
+        return False
+    monkeypatch.setattr(gpu_router, "_reload_model", _failing_reload)
+
+    tid = qm.track_request("test", "chat", "fresh-model:13b",
+                           qm.PRIORITY_INTERACTIVE)
+    with pytest.raises(RuntimeError, match="failed to load model"):
+        await qm.wait_for_dispatch(tid)
+
+
 # ── Reclaim cooperation ──────────────────────────────────────────────────────
 
 
@@ -698,6 +723,7 @@ async def test_run_batch_job_marks_activity_during_dispatch(tmp_path, monkeypatc
     # Stub the model swap so the dispatcher does not hit httpx itself.
     async def _noop_reload(gpu, model):
         gpu.model = model
+        return True
     monkeypatch.setattr(gpu_router, "_reload_model", _noop_reload)
 
     # Fake httpx client that blocks inside post() until released, so the
@@ -771,6 +797,7 @@ async def test_empty_response_fails_job_without_retry(tmp_path, monkeypatch):
 
     async def _noop_reload(gpu, model):
         gpu.model = model
+        return True
     monkeypatch.setattr(gpu_router, "_reload_model", _noop_reload)
 
     class _FakeResp:
@@ -832,6 +859,7 @@ async def test_batch_runner_lifts_think_flag_to_top_level(tmp_path, monkeypatch)
 
     async def _noop_reload(gpu, model):
         gpu.model = model
+        return True
     monkeypatch.setattr(gpu_router, "_reload_model", _noop_reload)
 
     captured: list[dict] = []

--- a/tests/test_queue_status.py
+++ b/tests/test_queue_status.py
@@ -93,6 +93,7 @@ def test_context_tokens_injected_into_done_line(tmp_path, monkeypatch):
     # Stub model swap so the dispatcher does not try to reach a real Ollama.
     async def _noop_reload(gpu, model):
         gpu.model = model
+        return True
     monkeypatch.setattr(gpu_router, "_reload_model", _noop_reload)
 
     done_chunk = json.dumps({


### PR DESCRIPTION
Closes #50

## Summary
- `gpu_router._reload_model` now uses `/api/embed` for embedding models (any model whose name contains `"embed"`) and `/api/generate` for everything else. Previously it unconditionally used `/api/generate`, which Ollama rejects with HTTP 400 for embedding-only models — so the warmup silently no-op'd.
- Added `resp.raise_for_status()` so a non-2xx warmup is a hard failure. `gpu.model` is only updated on success. Returns `bool`.
- `queue_manager._dispatch` checks the return value and raises on `False`, routing through the existing `handoff_fail` path so the GPU slot is released and the request is failed cleanly instead of handed off to a GPU that isn't actually ready.

## Root cause recap
`/api/generate` on `nomic-embed-text` returns HTTP 400 (`"nomic-embed-text" does not support generate`). The old `_reload_model` ignored status and flipped `gpu.model` anyway. Every time the reclaim loop swapped both GPUs back to `qwen3:32b` and lancellmot immediately started a document upload, the first `/api/embeddings` call triggered the *real* load and every concurrent embedding hit the GPU mid-load → 500 from Ollama → upload failed.

## Verification
```
unset OLLAMA_0_URL OLLAMA_1_URL
DB_PATH=:memory: pytest tests/ -v --tb=short -m "not stress and not integration"
```
→ **164 passed, 71 deselected** (was 161 — three new tests added).

New/updated tests:
- `test_reload_model_uses_embed_endpoint_for_embedding_models` — asserts `/api/embed` is used for nomic-embed-text with a non-empty `input`.
- `test_reload_model_returns_false_and_preserves_model_on_http_error` — non-2xx warmup returns False and leaves `gpu.model` untouched.
- `test_reload_model_omits_options_for_non_qwen3_generative` — old test renamed, now uses `llama3.1:8b` so it actually covers the generative branch.
- `test_dispatcher_fails_request_when_reload_fails` — dispatcher raises on `False` reload return, rather than silently handing the request off.

## Rollout
After merge, `compose up -d --build` on the merLLM stack to pick up the `api/` change (code is baked into the image).