### PR TITLE
Make Active Requests and Batch History tables sortable

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -559,14 +559,60 @@ function _priorityBadge(name) {
   return `<span class="priority-badge priority-${esc(safe)}">${esc(safe)}</span>`;
 }
 
-function renderQueueTable(queue) {
+// ── Table sorting ────────────────────────────────────────────────────────────
+
+const _sortState = {};
+let _lastQueueData = [];
+let _lastBatchData = [];
+
+function _sortRows(rows, key, dir) {
+  return [...rows].sort((a, b) => {
+    let va = a[key], vb = b[key];
+    if (va == null) va = "";
+    if (vb == null) vb = "";
+    if (typeof va === "number" && typeof vb === "number") return dir * (va - vb);
+    return dir * String(va).localeCompare(String(vb), undefined, { numeric: true });
+  });
+}
+
+function _handleSortClick(e) {
+  const th = e.target.closest("th.sortable");
+  if (!th) return;
+  const key = th.dataset.sortKey;
+  const table = th.closest("table");
+  const tbodyId = table.querySelector("tbody").id;
+
+  const prev = _sortState[tbodyId];
+  const dir = (prev && prev.key === key && prev.dir === 1) ? -1 : 1;
+  _sortState[tbodyId] = { key, dir };
+
+  table.querySelectorAll("th.sortable").forEach(h => h.classList.remove("sort-asc", "sort-desc"));
+  th.classList.add(dir === 1 ? "sort-asc" : "sort-desc");
+
+  if (tbodyId === "queue-tbody") renderQueueTable(_lastQueueData, true);
+  else if (tbodyId === "batch-tbody") renderBatchTable(_lastBatchData, true);
+}
+
+document.querySelectorAll("th.sortable").forEach(th =>
+  th.addEventListener("click", _handleSortClick)
+);
+
+function _applySortIfSet(rows, tbodyId) {
+  const s = _sortState[tbodyId];
+  if (s) return _sortRows(rows, s.key, s.dir);
+  return rows;
+}
+
+function renderQueueTable(queue, sortOnly) {
+  if (!sortOnly) _lastQueueData = queue || [];
   const tbody = document.getElementById("queue-tbody");
   if (!tbody) return;
-  if (!queue || !queue.length) {
+  const data = _applySortIfSet(_lastQueueData, "queue-tbody");
+  if (!data.length) {
     tbody.innerHTML = '<tr><td colspan="7" class="muted">No active requests.</td></tr>';
     return;
   }
-  tbody.innerHTML = queue.map(r => {
+  tbody.innerHTML = data.map(r => {
     const statusCls = r.status === "running" ? "pill-running"
       : r.status === "queued" ? "pill-queued"
       : r.status === "failed" ? "pill-failed" : "pill-completed";
@@ -605,27 +651,34 @@ function renderBucketLanes(buckets) {
 
 // ── Batch jobs ────────────────────────────────────────────────────────────────
 
+function renderBatchTable(jobs, sortOnly) {
+  if (!sortOnly) _lastBatchData = jobs || [];
+  const tbody = document.getElementById("batch-tbody");
+  if (!tbody) return;
+  const data = _applySortIfSet(_lastBatchData, "batch-tbody");
+  if (!data.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="muted">No jobs.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = data.map(j => `
+    <tr>
+      <td class="mono" style="font-size:11px">${j.id.substring(0, 8)}&hellip;</td>
+      <td>${esc(j.source_app)}</td>
+      <td>${esc(j.model)}</td>
+      <td><span class="status-pill pill-${j.status}">${j.status}</span></td>
+      <td class="muted" style="font-size:11px">${fmtTs(j.submitted_at)}</td>
+      <td>
+        ${j.status === "queued" ? `<button class="btn" style="padding:2px 8px;font-size:11px" onclick="cancelJob('${j.id}')">Cancel</button>` : ""}
+        ${j.status === "failed" ? `<button class="btn" style="padding:2px 8px;font-size:11px" onclick="requeueJob('${j.id}')">Requeue</button>` : ""}
+        ${j.status === "completed" ? `<button class="btn" style="padding:2px 8px;font-size:11px" onclick="viewResult('${j.id}')">Result</button>` : ""}
+      </td>
+    </tr>`).join("");
+}
+
 async function loadBatchJobs() {
   try {
     const jobs = await api("/api/batch/status");
-    const tbody = document.getElementById("batch-tbody");
-    if (!jobs || !jobs.length) {
-      tbody.innerHTML = '<tr><td colspan="6" class="muted">No jobs.</td></tr>';
-      return;
-    }
-    tbody.innerHTML = jobs.map(j => `
-      <tr>
-        <td class="mono" style="font-size:11px">${j.id.substring(0, 8)}&hellip;</td>
-        <td>${esc(j.source_app)}</td>
-        <td>${esc(j.model)}</td>
-        <td><span class="status-pill pill-${j.status}">${j.status}</span></td>
-        <td class="muted" style="font-size:11px">${fmtTs(j.submitted_at)}</td>
-        <td>
-          ${j.status === "queued" ? `<button class="btn" style="padding:2px 8px;font-size:11px" onclick="cancelJob('${j.id}')">Cancel</button>` : ""}
-          ${j.status === "failed" ? `<button class="btn" style="padding:2px 8px;font-size:11px" onclick="requeueJob('${j.id}')">Requeue</button>` : ""}
-          ${j.status === "completed" ? `<button class="btn" style="padding:2px 8px;font-size:11px" onclick="viewResult('${j.id}')">Result</button>` : ""}
-        </td>
-      </tr>`).join("");
+    renderBatchTable(jobs);
   } catch (err) {
     console.error("Batch load error:", err);
   }

--- a/web/index.html
+++ b/web/index.html
@@ -129,7 +129,7 @@
         <table>
           <thead>
             <tr>
-              <th>Source</th><th>Type</th><th>Model</th><th>Priority</th><th>GPU</th><th>Status</th><th>Elapsed</th>
+              <th class="sortable" data-sort-key="source">Source</th><th class="sortable" data-sort-key="request_type">Type</th><th class="sortable" data-sort-key="model">Model</th><th class="sortable" data-sort-key="priority">Priority</th><th class="sortable" data-sort-key="target">GPU</th><th class="sortable" data-sort-key="status">Status</th><th class="sortable" data-sort-key="elapsed_sec">Elapsed</th>
             </tr>
           </thead>
           <tbody id="queue-tbody"></tbody>
@@ -167,7 +167,7 @@
             <table>
               <thead>
                 <tr>
-                  <th>ID</th><th>Source</th><th>Model</th><th>Status</th><th>Submitted</th><th>Actions</th>
+                  <th class="sortable" data-sort-key="id">ID</th><th class="sortable" data-sort-key="source_app">Source</th><th class="sortable" data-sort-key="model">Model</th><th class="sortable" data-sort-key="status">Status</th><th class="sortable" data-sort-key="submitted_at">Submitted</th><th>Actions</th>
                 </tr>
               </thead>
               <tbody id="batch-tbody"></tbody>
@@ -366,6 +366,8 @@
           <strong style="color:var(--text)">Call-site rule</strong> — when a new LLM call site is added in any repo,
           read this table, pick the bucket, and cite it in a code comment. Keeping the bucket assignment explicit at
           every call site is what prevents the tiers from drifting back into an accidental mix.<br><br>
+          <strong style="color:var(--text)">Column sorting</strong> — click any column header in the Active
+          Requests or Batch History tables to sort by that column. Click again to reverse the sort order.<br><br>
           <strong style="color:var(--text)">Pause / resume</strong> — the Active Requests card on Overview
           has a Pause Queue button that stops the dispatcher from handing out new GPU slots. In-flight work
           finishes normally; new requests wait in their buckets until you press Resume. The pause flag is

--- a/web/styles.css
+++ b/web/styles.css
@@ -250,6 +250,11 @@ th {
   text-transform: uppercase;
   letter-spacing: .5px;
 }
+th.sortable { cursor: pointer; user-select: none; }
+th.sortable:hover { color: var(--text); }
+th.sortable::after { content: ""; margin-left: 4px; font-size: 9px; }
+th.sortable.sort-asc::after { content: "▲"; }
+th.sortable.sort-desc::after { content: "▼"; }
 td { padding: 7px 10px; border-bottom: 1px solid var(--border); }
 tr:last-child td { border-bottom: none; }
 tr:hover td { background: #1c2330; }


### PR DESCRIPTION
Closes #46

Adds client-side column sorting to both data tables on the Overview tab. Clicking a column header sorts ascending; clicking again reverses to descending. The sort state is preserved across auto-refresh poll cycles so the view doesn't jump while you're reading.

**Changes:**
- `web/index.html`: Added `data-sort-key` attributes and `sortable` class to `<th>` elements in Active Requests and Batch History tables. Added column-sorting note to embedded help.
- `web/app.js`: Added reusable sort infrastructure (`_sortState`, `_sortRows`, `_handleSortClick`, `_applySortIfSet`). Refactored `renderQueueTable` and extracted `renderBatchTable` to store last-fetched data and re-sort without re-fetching.
- `web/styles.css`: Added `.sortable` header styles with hover state and `▲`/`▼` indicators.

**Tests:** 178 passed, 2 pre-existing failures unrelated to this change (`test_integration::test_merllm_status` expects `round_robin` but live returns `fsm`; `test_stress::test_dispatcher_contention` flaky under load).

**Visual verification pending — automated agent. Manual browser check required before merge.**