### PR TITLE
fix(metrics): color the CPU legend swatches (#62)

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -768,7 +768,7 @@ function renderMetrics(m) {
         <span class="bar-wrap">${bar(avg)}<span style="width:36px;font-size:11px;text-align:right">${avg.toFixed(1)}%</span></span>
       </div>
       <div class="stat-row" style="margin-bottom:8px"><span class="stat-label">${cpuKeys.length} cores</span>
-        <span class="muted" style="font-size:11px">&#9632; &lt;30% &nbsp; &#9632; 30–70% &nbsp; &#9632; 70–90% &nbsp; &#9632; &gt;90%</span>
+        <span class="muted" style="font-size:11px"><span style="color:var(--green)">&#9632;</span> &lt;30% &nbsp; <span style="color:var(--accent)">&#9632;</span> 30–70% &nbsp; <span style="color:var(--yellow)">&#9632;</span> 70–90% &nbsp; <span style="color:var(--red)">&#9632;</span> &gt;90%</span>
       </div>
       <div class="cpu-grid">${cells}</div>`;
   }


### PR DESCRIPTION
Closes #62

## Summary

The CPU metrics panel renders a legend row (`■ <30%  ■ 30–70%  ■ 70–90%  ■ >90%`) that describes the colors in the heatmap grid. All four squares were rendered grey instead of their bucket colors. Root cause: the legend span carries `class=\"muted\"` which sets `color: var(--muted)`, and the unicode `■` glyphs inherit that text color.

Fix: wrap each `■` in an inline span whose color matches the bucket — `var(--green)` / `var(--accent)` / `var(--yellow)` / `var(--red)` — so the squares line up with the per-core cell colors set in `app.js:763`.

Scoped to `web/app.js` line 771; no logic or CSS changes.

## Test results

- `python3 -m pytest --ignore=tests/test_integration.py`: **178 passed, 1 failed**.
- The single failure (`tests/test_stress.py::TestQueueStress::test_dispatcher_contention`) is pre-existing and unrelated to this change (stress test on the dispatcher loop).
- `tests/test_integration.py::TestServiceHealth::test_merllm_status` also fails pre-existing (expects `routing == \"round_robin\"` but FSM refactor from #55 now returns `\"fsm\"`) — not touched here.

**Visual verification pending — automated agent. Manual browser check required before merge.**