### PR TITLE
fix(embeddings): honor X-Priority: chat override on /api/embeddings (#58)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -298,10 +298,14 @@ def _priority(request: Request) -> queue_manager.Priority:
     two-tier system. Unknown (non-empty) values fall back to ``BACKGROUND``
     so typos cannot silently escalate work to a higher lane.
 
-    Note: ``proxy_embeddings`` ignores this parser entirely and forces
-    ``Priority.EMBEDDINGS`` — embedding traffic is classified by endpoint,
-    not by header, so a missing or wrong ``X-Priority`` from any client
-    cannot route an embed into the wrong bucket.
+    Note: ``proxy_embeddings`` does not call this parser. It defaults
+    embeds to ``Priority.EMBEDDINGS`` and only honors one explicit
+    override — ``X-Priority: chat`` (or the ``interactive`` alias)
+    routes the embed to ``Priority.CHAT`` so a chat-path RAG embed
+    jumps ahead of ingest-chunk embeds (merLLM#58). Any other header
+    value still falls through to ``EMBEDDINGS``, so a missing or wrong
+    ``X-Priority`` from a non-chat client cannot route an embed into
+    the wrong bucket (preserves merLLM#38).
 
     TODO: once parsival and lancellmot are both sending explicit
     ``X-Priority`` on every call, tighten the missing-header default to
@@ -659,15 +663,24 @@ async def proxy_chat(request: Request):
 async def proxy_embeddings(request: Request):
     """Proxy POST /api/embeddings through the late-binding dispatcher.
 
-    Embedding traffic is auto-classified into ``Priority.EMBEDDINGS`` —
-    the incoming ``X-Priority`` header is intentionally ignored. Embedding
-    requests are sub-second on ``nomic-embed-text`` and have a dedicated
-    bucket so a burst of them never sits behind a 32b chat in the
-    ``background`` lane (see merLLM#38).
+    Embedding traffic defaults to ``Priority.EMBEDDINGS`` — a dedicated
+    bucket so a burst of ingest-chunk embeds never sits behind a 32b
+    chat in ``BACKGROUND`` (see merLLM#38). The only override honored
+    here is ``X-Priority: chat`` (or the legacy ``interactive`` alias),
+    which routes that single request to ``Priority.CHAT`` so a chat-path
+    RAG embed jumps ahead of ingest-chunk embeds (merLLM#58). Any other
+    ``X-Priority`` value — missing, unknown, or a lower bucket like
+    ``background`` — falls through to ``EMBEDDINGS``, so #38's narrow
+    rule (header can't silently route embeds into the wrong bucket) is
+    preserved for every non-chat caller.
     """
     body = await request.json()
     model = body.get("model", "")
-    priority = queue_manager.Priority.EMBEDDINGS
+    raw_priority = request.headers.get("x-priority")
+    if raw_priority and raw_priority.strip().lower() in ("chat", "interactive"):
+        priority = queue_manager.Priority.CHAT
+    else:
+        priority = queue_manager.Priority.EMBEDDINGS
     source = _source(request)
 
     tid = queue_manager.track_request(source, "embeddings", model, priority)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -733,13 +733,14 @@ class TestPriorityBucketContract:
             t.join(timeout=180)
 
     def test_embeddings_auto_classify_to_embeddings_bucket(self):
-        """PIN TEST: every /api/embeddings call lands in the embeddings bucket
-        regardless of the X-Priority header the caller sends.
+        """PIN TEST: a non-chat X-Priority on /api/embeddings still lands in
+        the embeddings bucket — the merLLM#58 override is narrow.
 
-        Embedding traffic is classified by endpoint, not by header — see
-        merLLM#38. We deliberately send ``X-Priority: background`` (the
-        wrong bucket, the one this whole change exists to escape) and
-        assert the proxy overrode it to ``embeddings``.
+        proxy_embeddings defaults to ``Priority.EMBEDDINGS`` and only
+        honors ``X-Priority: chat`` (or the ``interactive`` alias) as
+        an override (merLLM#58). Every other value — including the
+        lower ``background`` lane this whole bucket exists to escape
+        (merLLM#38) — must fall through to ``embeddings``.
         """
         source = f"integration_embed_{uuid.uuid4().hex[:8]}"
         t0 = time.time()
@@ -757,9 +758,63 @@ class TestPriorityBucketContract:
         )
         assert entry["request_type"] == "embeddings"
         assert entry["priority"] == "embeddings", (
-            f"embeddings call landed in {entry['priority']!r} despite the "
-            "endpoint forcing Priority.EMBEDDINGS — auto-classification "
-            "is broken (merLLM#38)"
+            f"embeddings call with X-Priority=background landed in "
+            f"{entry['priority']!r} — non-chat values must fall through "
+            "to EMBEDDINGS (merLLM#38)"
+        )
+
+    @pytest.mark.parametrize("header_value", ["chat", "interactive"])
+    def test_embeddings_chat_header_routes_to_chat_bucket(self, header_value):
+        """merLLM#58: ``X-Priority: chat`` on /api/embeddings routes to CHAT.
+
+        Chat-path RAG embeds are on the critical path of an interactive
+        response, so they jump ahead of ingest-chunk embeds that share
+        the ``embeddings`` bucket. The legacy ``interactive`` alias
+        must behave the same as ``chat``.
+        """
+        source = f"integration_embed_chat_{uuid.uuid4().hex[:8]}"
+        t0 = time.time()
+        r = post(
+            MERLLM, "/api/embeddings",
+            json={"model": "nomic-embed-text", "prompt": "chat-priority embed"},
+            headers={"X-Source": source, "X-Priority": header_value},
+        )
+        assert r.status_code == 200, (
+            f"/api/embeddings failed: {r.status_code} {r.text[:200]}"
+        )
+        entry = _find_queue_entry_by_source(source, after=t0, timeout=15.0)
+        assert entry is not None, (
+            f"no queue entry observed for chat-priority embed "
+            f"source={source!r}"
+        )
+        assert entry["request_type"] == "embeddings"
+        assert entry["priority"] == "chat", (
+            f"X-Priority={header_value!r} on /api/embeddings landed in "
+            f"{entry['priority']!r}, expected 'chat' (merLLM#58)"
+        )
+
+    def test_embeddings_typo_priority_falls_back_to_embeddings(self):
+        """merLLM#58: a typo in X-Priority on /api/embeddings must not
+        escalate — it falls through to EMBEDDINGS, not CHAT.
+
+        The override is a string-equality check on ``chat``/``interactive``;
+        anything else — including a near-miss like ``chta`` — stays in
+        EMBEDDINGS so a typo can't silently inflate priority.
+        """
+        source = f"integration_embed_typo_{uuid.uuid4().hex[:8]}"
+        t0 = time.time()
+        r = post(
+            MERLLM, "/api/embeddings",
+            json={"model": "nomic-embed-text", "prompt": "typo pin test"},
+            headers={"X-Source": source, "X-Priority": "chta"},
+        )
+        assert r.status_code == 200
+        entry = _find_queue_entry_by_source(source, after=t0, timeout=15.0)
+        assert entry is not None
+        assert entry["priority"] == "embeddings", (
+            f"typo X-Priority on /api/embeddings escalated to "
+            f"{entry['priority']!r} — only exact ``chat``/``interactive`` "
+            "is allowed to override, everything else stays in EMBEDDINGS"
         )
 
     def test_missing_priority_default_is_chat(self):


### PR DESCRIPTION
Closes #58

## Summary

`proxy_embeddings` now routes a single explicit `X-Priority: chat` (or the legacy `interactive` alias) to `Priority.CHAT` so a chat-path RAG embed jumps ahead of ingest-chunk embeds that share the `EMBEDDINGS` bucket. Every other `X-Priority` value — missing, unknown, `background`, or a typo — still falls through to `Priority.EMBEDDINGS`, preserving merLLM#38's rule that a wrong/missing header cannot route an embed into the wrong lane.

## Test results

- Non-integration suite: **164 passed, 74 deselected** locally.
- Integration coverage:
  - Updated existing `test_embeddings_auto_classify_to_embeddings_bucket` — still sends `X-Priority: background`, still asserts EMBEDDINGS (rule preserved), docstring now reflects the narrow override.
  - New `test_embeddings_chat_header_routes_to_chat_bucket` — parametrized over `chat` + `interactive` alias, asserts both land in CHAT.
  - New `test_embeddings_typo_priority_falls_back_to_embeddings` — `X-Priority: chta` stays in EMBEDDINGS, so typos can't inflate priority.

## Follow-up

Unblocks lancellmot#38 (chat router → rag.embed(priority="chat")).

Does **not** fix cross-bucket starvation when the required model isn't resident — that's merLLM#59, tracked separately.