### PR TITLE
Fix scheduler strict-priority starvation (#59)

### DIFF
--- a/api/scheduler.py
+++ b/api/scheduler.py
@@ -262,6 +262,52 @@ def _idle_ready_slot(slots: list[Slot], exclude: set[int]) -> Optional[int]:
     return None
 
 
+def _model_present(slots: list[Slot], model: str) -> bool:
+    for s in slots:
+        if s.state in (SlotState.READY, SlotState.BUSY) and s.model_loaded == model:
+            return True
+        if s.state is SlotState.LOADING and s.loading_model == model:
+            return True
+    return False
+
+
+def _model_served_elsewhere(
+    slots: list[Slot], model: str, exclude_idx: int
+) -> bool:
+    """True if some OTHER slot is BUSY or LOADING for ``model``.
+
+    "Served elsewhere" is the #59 starvation test: if this slot's model is
+    already in flight on another GPU, we can afford to skip this tick's
+    dispatch and let stage_pass LOAD a starved higher-priority model here.
+    """
+    for i, s in enumerate(slots):
+        if i == exclude_idx:
+            continue
+        if s.state is SlotState.BUSY and s.model_loaded == model:
+            return True
+        if s.state is SlotState.LOADING and s.loading_model == model:
+            return True
+    return False
+
+
+def _higher_bucket_blocked(
+    buckets: list[list[dict]], slots: list[Slot], p: int
+) -> Optional[tuple[int, str]]:
+    """Return ``(q, model)`` for the first higher-priority bucket q<p whose
+    head model is not present on any slot, else ``None``.
+
+    "Not present" means no slot is READY, BUSY, or LOADING for that model —
+    so dispatch cannot serve it this tick and stage_pass must load it.
+    """
+    for q in range(p):
+        if q >= len(buckets) or not buckets[q]:
+            continue
+        model = buckets[q][0]["model"]
+        if not _model_present(slots, model):
+            return (q, model)
+    return None
+
+
 def dispatch_pass(
     buckets: list[list[dict]], slots: list[Slot]
 ) -> tuple[list[Effect], list[Slot]]:
@@ -270,6 +316,15 @@ def dispatch_pass(
     Mutates ``buckets`` in place (pops). Returns ``(effects, updated_slots)``.
     Restarts from the top bucket after each pop so a higher-priority job
     arriving mid-dispatch cuts the line.
+
+    merLLM#59 starvation guard: if a higher-priority bucket is blocked
+    because its model is not resident on any slot, AND this bucket's
+    head model is already being served on another slot (BUSY/LOADING),
+    skip dispatching this tick. The idle READY slot is left available so
+    the companion ``stage_pass`` call can LOAD the starved model onto
+    it, unblocking the higher bucket on the next tick. Without the guard,
+    dispatch would repeatedly steal the only free slot and the
+    higher-priority bucket would starve indefinitely.
     """
     effects: list[Effect] = []
     progress = True
@@ -281,6 +336,16 @@ def dispatch_pass(
             head = buckets[p][0]
             slot_idx = _ready_slot_holding(slots, head["model"])
             if slot_idx is None:
+                continue
+            blocked = _higher_bucket_blocked(buckets, slots, p)
+            if blocked is not None and _model_served_elsewhere(
+                slots, head["model"], slot_idx
+            ):
+                tick_log.info(
+                    "[tick] starvation-guard skip bucket=%d head_model=%s "
+                    "slot_idx=%d blocked_bucket=%d blocked_model=%s",
+                    p, head["model"], slot_idx, blocked[0], blocked[1],
+                )
                 continue
             job = buckets[p].pop(0)
             new_slot, eff = transition(slots[slot_idx], Event.WORK_BEGIN, job=job)
@@ -322,20 +387,32 @@ def stage_pass(
 
     # First pass: any slot already holding / loading / running a demanded
     # model is treated as satisfying that demand — no speculative load.
+    # Prefer BUSY/LOADING satisfiers over READY ones so idle READY slots
+    # stay available for second-pass LOAD_BEGIN of unmet higher-priority
+    # demands (merLLM#59). Otherwise a READY slot that "coincidentally"
+    # holds the same model as a running job gets consumed here, leaving
+    # nowhere to load a starved model.
     for di, model in enumerate(demand):
+        best_si: Optional[int] = None
+        best_rank: Optional[int] = None
         for si, s in enumerate(slots):
             if si in used_slots:
                 continue
-            holds_it = (
-                s.state in (SlotState.READY, SlotState.BUSY)
-                and s.model_loaded == model
-            ) or (
-                s.state is SlotState.LOADING and s.loading_model == model
-            )
-            if holds_it:
-                used_slots.add(si)
-                satisfied_demands.add(di)
-                break
+            if s.state is SlotState.BUSY and s.model_loaded == model:
+                rank = 0
+            elif s.state is SlotState.LOADING and s.loading_model == model:
+                rank = 0
+            elif s.state is SlotState.READY and s.model_loaded == model:
+                rank = 1
+            else:
+                continue
+            if best_rank is None or rank < best_rank:
+                best_si, best_rank = si, rank
+                if rank == 0:
+                    break
+        if best_si is not None:
+            used_slots.add(best_si)
+            satisfied_demands.add(di)
 
     # Second pass: unmet demands seek an idle READY slot to load onto.
     for di, model in enumerate(demand):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -328,15 +328,68 @@ def test_dispatch_restart_from_top_after_each_pop():
 
 
 def test_dispatch_skips_bucket_whose_head_has_no_matching_slot():
-    """Priority inversion by design: if CHAT wants a model no slot holds, but
-    BACKGROUND wants a model that IS loaded, BACKGROUND runs. stage_pass
-    will separately kick off a load for the CHAT model."""
+    """Single-slot case: if CHAT wants a model no slot holds, but BACKGROUND
+    wants a model that IS loaded, BACKGROUND runs. The #59 starvation guard
+    does NOT fire here because the BG model is not being "served elsewhere"
+    — there are no other slots. stage_pass handles loading the CHAT model
+    on a later tick once a slot is free."""
     buckets = _buckets(p0=[job("unloaded", "chat")], p4=[job("m", "bg")])
     slots = [Slot(url=GPU, state=SlotState.READY, model_loaded="m")]
     eff, slots = dispatch_pass(buckets, slots)
     assert len(eff) == 1
     assert eff[0].data["job"]["id"] == "bg"
     assert len(buckets[0]) == 1  # CHAT job preserved for next tick
+
+
+def test_dispatch_starvation_guard_holds_bg_when_chat_starved_and_bg_running_elsewhere(caplog):
+    """merLLM#59: CHAT wants a model no slot holds. BG wants a model that's
+    already running on slot0 AND a second slot is idle READY with the same
+    model. Dispatch must NOT hand the idle slot to BG — it must leave it
+    free so the companion stage_pass can LOAD the starved CHAT model onto
+    it. Without the guard, dispatch repeatedly steals the only free slot
+    and CHAT starves indefinitely while BG drains."""
+    import logging as _logging
+    buckets = _buckets(
+        p0=[job("qwen3:30b-thinking", "chat")],
+        p4=[job("qwen3:32b", "bg")],
+    )
+    slots = [
+        Slot(url=GPU,  state=SlotState.BUSY,  model_loaded="qwen3:32b",
+             current_job=job("qwen3:32b", "inflight")),
+        Slot(url=GPU1, state=SlotState.READY, model_loaded="qwen3:32b"),
+    ]
+    with caplog.at_level(_logging.INFO, logger="merllm.scheduler.tick"):
+        eff, slots_after = dispatch_pass(buckets, slots)
+    assert eff == []
+    assert len(buckets[0]) == 1
+    assert len(buckets[4]) == 1
+    assert slots_after[1].state is SlotState.READY
+    # Diagnostic log must fire so the skip is observable in production.
+    assert any("starvation-guard" in rec.message for rec in caplog.records)
+
+
+def test_dispatch_guard_permits_first_bg_dispatch_then_reserves_second_slot():
+    """With 2 idle READY slots holding the BG model and CHAT starved,
+    one BG dispatch still lands (no slot is 'served elsewhere' yet). On
+    the second inner-loop iteration slot0 has become BUSY, so the guard
+    fires and the remaining READY slot is reserved for stage_pass to LOAD
+    the starved CHAT model. End state: 1 BG dispatched, 1 slot still free."""
+    buckets = _buckets(
+        p0=[job("qwen3:30b-thinking", "chat")],
+        p4=[job("qwen3:32b", "bg-a"), job("qwen3:32b", "bg-b")],
+    )
+    slots = [
+        Slot(url=GPU,  state=SlotState.READY, model_loaded="qwen3:32b"),
+        Slot(url=GPU1, state=SlotState.READY, model_loaded="qwen3:32b"),
+    ]
+    eff, slots_after = dispatch_pass(buckets, slots)
+    assert len(eff) == 1
+    assert eff[0].data["job"]["id"] == "bg-a"
+    assert buckets[0] == [job("qwen3:30b-thinking", "chat")]
+    assert len(buckets[4]) == 1  # bg-b reserved for next tick after CHAT gets a slot
+    # Exactly one slot stayed READY — that's the one stage_pass will claim.
+    ready_count = sum(1 for s in slots_after if s.state is SlotState.READY)
+    assert ready_count == 1
 
 
 def test_dispatch_requires_ready_state_not_busy_or_loading():
@@ -445,6 +498,53 @@ def test_stage_treats_in_progress_load_as_satisfying_demand():
     # The in-progress load on slot 0 satisfies demand 0; mirror fills slot 1.
     assert len(eff) == 1
     assert eff[0].data["url"] == GPU1
+
+
+def test_stage_prefers_busy_satisfier_over_ready_for_same_model():
+    """merLLM#59: when both BUSY and READY slots hold the demanded model,
+    first-pass matching must pick BUSY so the READY slot stays free for a
+    second-pass LOAD_BEGIN of any unmet higher-priority demand. Without
+    this preference, the READY slot gets consumed by a demand that's
+    already being served, leaving unmet demands nowhere to load."""
+    # p0 demands model "a" (no slot holds it), p2 demands model "m"
+    # (both slots hold it). The READY+m slot must be reserved to load "a".
+    buckets = _buckets(p0=[job("a", "ja")], p2=[job("m", "jm")])
+    slots = [
+        Slot(url=GPU,  state=SlotState.READY, model_loaded="m"),
+        Slot(url=GPU1, state=SlotState.BUSY,  model_loaded="m",
+             current_job=job("m", "inflight")),
+    ]
+    eff, slots = stage_pass(buckets, slots)
+    # Exactly one load: model "a" onto the READY slot. The BUSY slot
+    # satisfies the "m" demand.
+    assert len(eff) == 1
+    assert eff[0].data["url"] == GPU
+    assert eff[0].data["model"] == "a"
+    assert slots[0].state is SlotState.LOADING
+    assert slots[0].loading_model == "a"
+
+
+def test_stage_loads_starved_model_onto_idle_slot_companion_to_dispatch_guard():
+    """merLLM#59 companion test: when dispatch_pass yields to the guard
+    (BG running on slot0, slot1 idle with BG model, CHAT starved for a
+    different model), stage_pass must LOAD the CHAT model onto slot1.
+    This is the other half of the starvation fix — dispatch yields the
+    slot and stage claims it."""
+    buckets = _buckets(
+        p0=[job("qwen3:30b-thinking", "chat")],
+        p4=[job("qwen3:32b", "bg")],
+    )
+    slots = [
+        Slot(url=GPU,  state=SlotState.BUSY,  model_loaded="qwen3:32b",
+             current_job=job("qwen3:32b", "inflight")),
+        Slot(url=GPU1, state=SlotState.READY, model_loaded="qwen3:32b"),
+    ]
+    eff, slots = stage_pass(buckets, slots)
+    assert [e.kind for e in eff] == ["load"]
+    assert eff[0].data["url"] == GPU1
+    assert eff[0].data["model"] == "qwen3:30b-thinking"
+    assert slots[1].state is SlotState.LOADING
+    assert slots[1].loading_model == "qwen3:30b-thinking"
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #59.

## Problem

In the FSM scheduler, when a higher-priority bucket's model is not resident on any slot AND a lower-priority bucket's model is running on another slot, `dispatch_pass` would repeatedly hand the only idle READY slot to the lower bucket. The higher bucket starves indefinitely because `stage_pass` never gets a free slot to LOAD the starved model.

## Fix

Two coordinated changes in `api/scheduler.py`:

1. **`dispatch_pass` starvation guard** — skip dispatching bucket `p` when (a) some higher bucket `q<p` is blocked (its head model not present anywhere) and (b) bucket `p`'s head model is BUSY/LOADING on a slot other than the candidate. The idle slot yields to `stage_pass`. Logs `[tick] starvation-guard skip ...` for diagnostic visibility.

2. **`stage_pass` BUSY-preference** — first-pass demand-to-slot matching prefers BUSY/LOADING satisfiers over READY. Without this, a READY slot holding the same model as a running job gets consumed by the satisfied demand, leaving unmet starved demands nowhere to LOAD.

Either change alone is insufficient; both are required (different scenarios surface each).

## Tests

- `test_dispatch_starvation_guard_holds_bg_when_chat_starved_and_bg_running_elsewhere` — pins the dispatch-side fix + diagnostic log
- `test_dispatch_guard_permits_first_bg_dispatch_then_reserves_second_slot` — confirms guard doesn't kill throughput when not needed
- `test_stage_prefers_busy_satisfier_over_ready_for_same_model` — pins the stage-side preference fix
- `test_stage_loads_starved_model_onto_idle_slot_companion_to_dispatch_guard` — end-to-end companion: dispatch yields, stage claims

Existing `test_dispatch_skips_bucket_whose_head_has_no_matching_slot` updated only with a clarifying docstring (single-slot case still behaves the same — guard's "served elsewhere" condition can't fire with one slot).

Full FSM suite: 67/67 passing.