### PR TITLE
UI/API cleanup for FSM refactor Phase 4 (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ Every request that lands on merLLM is placed in one of five priority buckets. Th
 
 **Call-site assignment rule** — each call site picks its bucket once and declares it on every request via the `X-Priority` header. Callers do not get to promote themselves at runtime. If a request has no `X-Priority` header, merLLM currently defaults it to `chat` for back-compat during the rollout; unknown string values fall back to `background` so typos cannot escalate. The one exception is `/api/embeddings`, which ignores the header entirely and always lands in bucket 2 — embedding traffic is classified by endpoint, not by caller intent.
 
-The dispatcher state is visible on the dashboard's Queue tab (one lane per bucket, with live depth) and machine-readably at `GET /api/merllm/queue`, which includes a `buckets` map keyed by bucket name.
+The dispatcher state is visible on the dashboard's Overview tab (one lane per bucket, with live depth) and machine-readably at `GET /api/merllm/queue`, which includes a `buckets` map keyed by bucket name.
+
+**Observable scheduler status** — `GET /api/merllm/status` returns a `scheduler_status` field set to one of six values: `recovering` (boot reconciliation in flight), `paused` (operator pause), `degraded` (every slot unreachable), `draining` (a slot is BUSY or LOADING), `dispatching` (a READY slot has work to pick up), or `idle`. This is a pure projection of `(paused, recovered, slots, buckets_nonempty)` defined in `scheduler.project_status`; the dispatcher itself does not consult it. Surfaced on the GPU Router card on Overview for at-a-glance health.
 
 ## Batch jobs
 
-Jobs submitted via `POST /api/batch/submit` are persisted in SQLite and run in the **background** bucket (bucket 5) whenever every higher bucket is empty. They survive restarts; directly-submitted `X-Priority: background` requests do not.
+A batch job is a fire-and-forget submission that enters the *same* unified queue as chat and embedding traffic, at bucket 5 (**background**). There is no separate batch queue — `POST /api/batch/submit` persists the job in SQLite, then runs it through the shared 5-bucket dispatcher whenever every higher bucket is empty. Persistence is what distinguishes a batch job from a directly-submitted `X-Priority: background` request; only batch jobs survive restarts.
 
 Prompts exceeding `BATCH_MAX_PROMPT_LEN` characters are rejected with HTTP 422.
 
@@ -214,7 +216,7 @@ Interval: 30s, timeout: 5s, retries: 3.
 
 | Tab | Contents |
 |---|---|
-| Overview | My Day panel, GPU state, Ollama health, per-GPU live activity (model, token stream, chunk count via SSE), batch counts |
+| Overview | My Day panel, GPU state, observable scheduler status, Ollama health, per-GPU live activity (model, token stream, chunk count via SSE), priority-bucket lanes, active requests, batch-job submission + history |
 | Batch Jobs | Submit jobs, view queue, cancel/requeue; failed jobs show retry count |
 | Metrics | Time-series charts (Chart.js) for CPU, RAM, disk, GPU utilization, GPU VRAM, GPU temperature, network throughput; range selector: 1h / 6h / 24h / 7d |
 | Logs | Live log tail from any Docker container (configurable via `LOG_CONTAINER_*` env vars) |

--- a/api/app.py
+++ b/api/app.py
@@ -696,13 +696,13 @@ async def merllm_status():
 
     return {
         **gpu_router.status(),
-        "queue":         queue_manager.queue_depth(),
-        "queue_paused":  queue_manager.is_paused(),
+        "queue":              queue_manager.queue_depth(),
+        "queue_paused":       queue_manager.is_paused(),
         "queue_paused_since": queue_manager.paused_since(),
-        "ollama":        ollama_health,
-        "gpu_metrics":   metrics.gpu_snapshot(),
-        "batch_counts":  db.count_batch_jobs_by_status(),
-        "warnings":      _build_warnings(ollama_health, latest),
+        "scheduler_status":   queue_manager.scheduler_status(),
+        "ollama":             ollama_health,
+        "gpu_metrics":        metrics.gpu_snapshot(),
+        "warnings":           _build_warnings(ollama_health, latest),
     }
 
 

--- a/api/queue_manager.py
+++ b/api/queue_manager.py
@@ -129,6 +129,12 @@ class EmptyResponseError(Exception):
 _paused: bool = False
 _paused_since: Optional[float] = None
 
+# Flipped True once :func:`_boot_reconcile` has seeded slot state and drained
+# stale ``pending_work`` rows. Read by the observable-status projection so the
+# dashboard shows ``recovering`` instead of ``idle`` during the brief window
+# before boot probes resolve.
+_recovered: bool = False
+
 # Callback notified on every track/start/complete/fail so the SSE layer can
 # push updates. Set by app.py at startup.
 _on_queue_change: Optional[callable] = None
@@ -516,6 +522,19 @@ def pipe_depth() -> dict:
     depths["interactive"] = depths["chat"]
     depths["batch"]       = depths["background"]
     return depths
+
+
+def scheduler_status() -> str:
+    """Current observable scheduler status as a lowercase string.
+
+    Pure projection of (paused, recovered, slots, buckets). Used by the
+    dashboard Overview tab to surface one of: ``recovering``, ``paused``,
+    ``degraded``, ``draining``, ``dispatching``, ``idle``.
+    """
+    return project_status(
+        paused=_paused, recovered=_recovered,
+        slots=_slots, buckets_nonempty=any(_buckets_v2),
+    ).value
 
 
 # ── Batch job submission ──────────────────────────────────────────────────────
@@ -940,6 +959,9 @@ async def _boot_reconcile() -> None:
     log.info("[boot] reconciled slots=%s stale_pending_cleared=%d",
              slot_summary, stale)
 
+    global _recovered
+    _recovered = True
+
 
 # ── v2: effect application ──────────────────────────────────────────────────
 
@@ -1163,7 +1185,7 @@ async def _tick_once() -> dict:
     staged     = _drive_pass("stage",    stage_pass)
     if dispatched or staged:
         status = project_status(
-            paused=_paused, recovered=True,
+            paused=_paused, recovered=_recovered,
             slots=_slots, buckets_nonempty=any(_buckets_v2),
         )
         log_tick_summary(

--- a/web/app.js
+++ b/web/app.js
@@ -245,6 +245,26 @@ function updateBadge(status) {
   }
 }
 
+// Observable scheduler status — one of recovering / paused / degraded /
+// draining / dispatching / idle (pure projection of queue_manager state).
+const _SCHEDULER_STATUS_LABEL = {
+  recovering:  { text: "recovering",  cls: "sched-warn" },
+  paused:      { text: "paused",      cls: "sched-warn" },
+  degraded:    { text: "degraded",    cls: "sched-fault" },
+  draining:    { text: "draining",    cls: "sched-ok" },
+  dispatching: { text: "dispatching", cls: "sched-ok" },
+  idle:        { text: "idle",        cls: "sched-muted" },
+};
+
+function renderSchedulerStatus(status) {
+  const el = document.getElementById("ov-scheduler-status");
+  if (!el) return;
+  const info = _SCHEDULER_STATUS_LABEL[status];
+  if (!info) { el.textContent = status || "—"; el.className = "stat-value"; return; }
+  el.textContent = info.text;
+  el.className = "stat-value " + info.cls;
+}
+
 function renderOverview(s) {
   // Warnings
   const warn = document.getElementById("warnings");
@@ -258,6 +278,7 @@ function renderOverview(s) {
 
   // GPU Router card
   set("ov-routing", s.routing || "round_robin");
+  renderSchedulerStatus(s.scheduler_status);
   set("ov-default-model", s.default_model || "—");
   const q = s.queue || {};
   const qTotal = (q.queued || 0) + (q.running || 0);
@@ -334,22 +355,6 @@ function renderOverview(s) {
            </div>`;
       }
     }
-  }
-
-  // Queue summary + batch counts
-  const bc = document.getElementById("batch-counts");
-  if (bc) {
-    let rows = "";
-    if (s.queue) {
-      rows += `<div class="stat-row"><span class="stat-label">Running</span><span class="stat-value">${s.queue.running || 0}</span></div>`;
-      rows += `<div class="stat-row"><span class="stat-label">Queued</span><span class="stat-value">${s.queue.queued || 0}</span></div>`;
-    }
-    if (s.batch_counts) {
-      Object.entries(s.batch_counts).forEach(([k, v]) => {
-        rows += `<div class="stat-row"><span class="stat-label">Batch ${esc(k)}</span><span class="stat-value">${v}</span></div>`;
-      });
-    }
-    bc.innerHTML = rows || '<span class="muted">No queue data</span>';
   }
 
   // GPU hardware metrics

--- a/web/index.html
+++ b/web/index.html
@@ -52,6 +52,10 @@
           <span id="ov-routing" class="stat-value">—</span>
         </div>
         <div class="stat-row">
+          <span class="stat-label">Scheduler</span>
+          <span id="ov-scheduler-status" class="stat-value">—</span>
+        </div>
+        <div class="stat-row">
           <span class="stat-label">Default model</span>
           <span id="ov-default-model" class="stat-value">—</span>
         </div>
@@ -60,7 +64,7 @@
           <span id="ov-pending-model" class="stat-value" style="color:var(--yellow)">—</span>
         </div>
         <div class="stat-row">
-          <span class="stat-label">Active requests</span>
+          <span class="stat-label">In flight</span>
           <span id="ov-queue" class="stat-value">—</span>
         </div>
         <div id="gpu-router-cards"></div>
@@ -70,10 +74,6 @@
         <h2>Ollama Instances</h2>
         <div id="ollama-gpu0" class="instance-card">Loading&hellip;</div>
         <div id="ollama-gpu1" class="instance-card" style="margin-top:10px">Loading&hellip;</div>
-        <div class="mt">
-          <h2>GPU Queue</h2>
-          <div id="batch-counts"></div>
-        </div>
       </div>
 
       <div class="card">
@@ -368,6 +368,15 @@
           every call site is what prevents the tiers from drifting back into an accidental mix.<br><br>
           <strong style="color:var(--text)">Column sorting</strong> — click any column header in the Active
           Requests or Batch History tables to sort by that column. Click again to reverse the sort order.<br><br>
+          <strong style="color:var(--text)">Scheduler status</strong> — the GPU Router card on Overview shows
+          one of six observable states:
+          <code>recovering</code> (boot reconciliation in flight),
+          <code>paused</code> (operator pause),
+          <code>degraded</code> (every slot unreachable),
+          <code>draining</code> (a slot is BUSY or LOADING),
+          <code>dispatching</code> (a READY slot has work to pick up), or
+          <code>idle</code> (no work, no in-flight). This is a pure projection of scheduler state for
+          observability; the scheduler itself does not consult it.<br><br>
           <strong style="color:var(--text)">Pause / resume</strong> — the Active Requests card on Overview
           has a Pause Queue button that stops the dispatcher from handing out new GPU slots. In-flight work
           finishes normally; new requests wait in their buckets until you press Resume. The pause flag is
@@ -394,8 +403,11 @@
       <div class="card">
         <h2>Batch Jobs</h2>
         <p style="color:var(--muted);font-size:13px;line-height:1.7">
-          Batch jobs run at bucket 5 (<code>background</code>) — they only dispatch when every higher bucket is
-          empty. Chat, short foreground work, and feedback work all take priority.<br><br>
+          A batch job is a fire-and-forget submission that merLLM persists in SQLite and runs on its own.
+          It enters the <em>same</em> unified queue as chat and embedding traffic, just at bucket 5
+          (<code>background</code>), so it only dispatches when every higher bucket is empty. There is no
+          separate batch queue — the &ldquo;Batch Jobs&rdquo; card here is the submission and history
+          surface for background-bucket work.<br><br>
           <strong style="color:var(--text)">Automatic retry</strong> — failed jobs are retried up to
           <code>BATCH_MAX_RETRIES</code> times (default 2, giving 3 total attempts) with exponential
           backoff (30s, 120s). On final failure, the error messages are stored on the job record.<br><br>

--- a/web/styles.css
+++ b/web/styles.css
@@ -273,6 +273,12 @@ tr:hover td { background: #1c2330; }
 .pill-failed    { background: #3b1c1c; color: var(--red); }
 .pill-cancelled { background: #2a2a2a; color: var(--muted); }
 
+/* Scheduler status — observable projection surfaced on the GPU Router card. */
+.sched-ok    { color: var(--green); }
+.sched-warn  { color: var(--warn, #e6a700); }
+.sched-fault { color: var(--red); }
+.sched-muted { color: var(--muted); }
+
 /* Settings form */
 .settings-form { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 20px; }
 .form-group { display: flex; flex-direction: column; gap: 4px; }


### PR DESCRIPTION
Closes #56

## Summary

Surface the observable scheduler status on the dashboard and remove the vestigial UI surface that made batch jobs look like a second queue, delivering the Phase 4 cleanup that #52 deferred.

- New `queue_manager.scheduler_status()` projects `(paused, recovered, slots, buckets)` through `scheduler.project_status` and returns one of `recovering`, `paused`, `degraded`, `draining`, `dispatching`, `idle`. A `_recovered` flag is now tracked in the module and flipped at the end of `_boot_reconcile`, so the `recovering` state can actually surface during boot (previously the tick body passed `recovered=True` literal).
- `GET /api/merllm/status` now returns `scheduler_status`. The unused `batch_counts` field (vestigial batch-counts-beside-queue-counts data) is dropped; no caller consumed it after the GPU Queue subsection removal below.
- GPU Router card on Overview gains a color-coded "Scheduler" row. The redundant "GPU Queue" subsection inside the Ollama Instances card is removed — Priority Buckets and Active Requests already cover that space. "Active requests" counter renamed to "In flight" to match what it sums (queued + running).
- Help text: adds a scheduler-status paragraph to the GPU Queue help card and reframes the Batch Jobs help to make explicit that a batch job is a persisted submission into bucket 5 of the unified queue, not a separate queue.
- README: documents `scheduler_status` and clarifies the unified-queue model.

## Test results

- `pytest tests/ --ignore=tests/test_integration.py` → 202 passed in 2.68s.
- `tests/test_integration.py::TestChatE2E::test_chat_stream_with_rag_status` failed with `httpx.ReadTimeout` during a live GPU chat stream; unrelated to this change (no queue_manager/app.py status paths touched by this PR participate in that flow beyond the already-covered `scheduler_status` addition).
- Module import smoke: `queue_manager.scheduler_status()` returns `recovering` before `_boot_reconcile`, matching the intended `_recovered=False` initial state.

**Visual verification pending — automated agent. Manual browser check required before merge.**