### PR TITLE
Buffer-stream non-streaming /api/generate and /api/chat (#64)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -509,6 +509,75 @@ async def _queued_stream(path: str, body: dict,
     return StreamingResponse(generate(), media_type="application/x-ndjson")
 
 
+async def _stream_and_accumulate(target: str, path: str, body: dict) -> dict:
+    """Buffer-stream Ollama NDJSON and return the single-JSON payload shape.
+
+    Forces ``stream=True`` on the wire so every NDJSON line ticks
+    ``_activity_inc`` + ``_activity_append_token`` (the instance card's tok
+    counter + rolling text buffer), then accumulates the streamed tokens into
+    the same dict shape a ``stream=False`` request would have returned.
+    Caller-facing wire contract is unchanged; only the Ollama-facing request
+    is rewritten. ``stream`` is wire-format only — KV cache / num_ctx /
+    num_predict are identical in both modes.
+    """
+    wire_body = {**body, "stream": True}
+    text, thinking = "", ""
+    final: dict = {}
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(config.PROXY_READ_TIMEOUT_SECONDS),
+    ) as client:
+        async with client.stream("POST", f"{target}{path}", json=wire_body) as resp:
+            resp.raise_for_status()
+            buf = b""
+            async for chunk in resp.aiter_bytes():
+                buf += chunk
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    if not line.strip():
+                        continue
+                    _activity_inc(target)
+                    _activity_append_token(target, line, path)
+                    try:
+                        obj = json.loads(line)
+                    except Exception:
+                        continue
+                    if path == "/api/generate":
+                        text += obj.get("response", "") or ""
+                    elif path == "/api/chat":
+                        msg = obj.get("message") or {}
+                        text     += msg.get("content", "")  or ""
+                        thinking += msg.get("thinking", "") or ""
+                    if obj.get("done"):
+                        final = obj
+    if path == "/api/generate":
+        final["response"] = text
+    elif path == "/api/chat":
+        msg = dict(final.get("message") or {"role": "assistant"})
+        msg["content"] = text
+        if thinking:
+            msg["thinking"] = thinking
+        final["message"] = msg
+    return final
+
+
+async def _buffered_stream_proxy(target: str, path: str, body: dict) -> Response:
+    """Non-streaming wire contract, streamed internally for live card updates.
+
+    Used for generate/chat when the caller sends ``stream: False``. Wraps
+    ``_activity_set`` / ``_activity_clear`` around ``_stream_and_accumulate``
+    so the instance card shows model+endpoint for the full call duration
+    while the tok counter ticks per line.
+    """
+    model = body.get("model", "")
+    _activity_set(target, model, path)
+    try:
+        payload = await _stream_and_accumulate(target, path, body)
+        return Response(content=json.dumps(payload).encode(),
+                        media_type="application/json")
+    finally:
+        _activity_clear(target)
+
+
 async def _proxy(target: str, path: str, body: dict) -> Response:
     """Non-streaming Ollama proxy (e.g. embeddings), tracking activity per instance."""
     model = body.get("model", "")
@@ -553,10 +622,18 @@ async def _proxy_nonstream(path: str, body: dict, tid: str) -> Response:
     The ``queue_manager.dispatched`` CM owns slot lifecycle: release on
     happy path, fail_request on exception, cancel_tracked on pre-dispatch
     caller exit. No handler-side cleanup flags needed.
+
+    For generate/chat, routes through ``_buffered_stream_proxy`` so the
+    instance card's tok counter ticks per NDJSON line even when the caller
+    sent ``stream: False``. Embeddings/show/pull stay on the plain ``_proxy``
+    path — no NDJSON to accumulate.
     """
     try:
         async with queue_manager.dispatched(tid) as target:
-            resp = await _proxy(target, path, body)
+            if path in ("/api/generate", "/api/chat"):
+                resp = await _buffered_stream_proxy(target, path, body)
+            else:
+                resp = await _proxy(target, path, body)
             gpu_router.record_activity(target)
             return resp
     except queue_manager.DispatchTimeout:

--- a/api/queue_manager.py
+++ b/api/queue_manager.py
@@ -745,16 +745,15 @@ async def _run_batch_job_async(job_id: str) -> None:
         ) as t:
             target = t
             _app._activity_set(target, job["model"], "/api/generate")
-            # Bounded read timeout: defence-in-depth behind the tick's
-            # busy-slot timeout sweep. If the slot has already been driven
-            # through WORK_END(timeout), this still eventually unblocks the
-            # coroutine instead of leaking the httpx connection forever.
-            async with httpx.AsyncClient(
-                timeout=httpx.Timeout(config.PROXY_READ_TIMEOUT_SECONDS),
-            ) as client:
-                resp = await client.post(f"{target}/api/generate", json=body)
-                resp.raise_for_status()
-                payload = resp.json()
+            # Buffer-stream the Ollama response so the instance card's tok
+            # counter ticks per NDJSON line for the full batch run (#64).
+            # Wire-contract to the caller is unchanged; ``stream`` is only
+            # flipped on the Ollama-facing body. The PROXY_READ_TIMEOUT
+            # bound lives inside _stream_and_accumulate, behind the tick's
+            # busy-slot timeout sweep.
+            payload = await _app._stream_and_accumulate(
+                target, "/api/generate", body
+            )
             gpu_router.record_activity(target)
             result_text = _validate_batch_response(payload, options)
             db.update_batch_job(job_id, status="completed",

--- a/tests/test_buffered_stream.py
+++ b/tests/test_buffered_stream.py
@@ -1,0 +1,183 @@
+"""tests/test_buffered_stream.py — Tests for #64 buffer-stream path.
+
+Covers ``_stream_and_accumulate`` and ``_buffered_stream_proxy``:
+- wire response shape matches a ``stream=False`` Ollama call
+- ``_activity_inc`` ticks once per NDJSON line so the instance card's
+  tok counter updates mid-call for batch + extractor traffic.
+"""
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "api"))
+
+
+class _FakeStreamResp:
+    """Mimic the object returned by ``httpx.AsyncClient.stream`` CM."""
+
+    def __init__(self, lines: list[bytes]):
+        # Split each NDJSON line across two chunks to exercise the
+        # buffer-split path (mid-line chunk boundary).
+        self._chunks = []
+        for ln in lines:
+            mid = max(1, len(ln) // 2)
+            self._chunks.append(ln[:mid])
+            self._chunks.append(ln[mid:] + b"\n")
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self):
+        for c in self._chunks:
+            yield c
+
+
+class _FakeStreamCM:
+    def __init__(self, lines: list[bytes]):
+        self._lines = lines
+
+    async def __aenter__(self):
+        return _FakeStreamResp(self._lines)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeClient:
+    """Mimic ``httpx.AsyncClient`` for the .stream() path used by accumulator."""
+
+    def __init__(self, lines: list[bytes]):
+        self._lines = lines
+        self.stream_calls: list[tuple[str, str, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def stream(self, method: str, url: str, json: dict):  # noqa: A002
+        self.stream_calls.append((method, url, json))
+        return _FakeStreamCM(self._lines)
+
+
+@pytest.fixture
+def app_mod(tmp_path, monkeypatch):
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "test.db"))
+    for mod in list(sys.modules.keys()):
+        if mod in ("app", "db", "config", "queue_manager", "gpu_router",
+                   "metrics", "notifications"):
+            sys.modules.pop(mod, None)
+    import app as app_mod
+    return app_mod
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_accumulate_generate_wire_shape(app_mod, monkeypatch):
+    """/api/generate: accumulated payload has .response + .done + metadata."""
+    lines = [
+        json.dumps({"response": "Hello "}).encode(),
+        json.dumps({"response": "world"}).encode(),
+        json.dumps({
+            "response":           "",
+            "done":               True,
+            "done_reason":        "stop",
+            "prompt_eval_count":  7,
+            "eval_count":         3,
+        }).encode(),
+    ]
+    fake = _FakeClient(lines)
+    monkeypatch.setattr(app_mod.httpx, "AsyncClient", lambda **kw: fake)
+
+    payload = _run(app_mod._stream_and_accumulate(
+        "http://fake:11434", "/api/generate", {"model": "m", "prompt": "p"}
+    ))
+
+    assert payload["response"] == "Hello world"
+    assert payload["done"] is True
+    assert payload["done_reason"] == "stop"
+    assert payload["prompt_eval_count"] == 7
+    # Wire body flipped stream=True even though caller body had no flag.
+    assert fake.stream_calls[0][2]["stream"] is True
+
+
+def test_accumulate_chat_wire_shape(app_mod, monkeypatch):
+    """/api/chat: accumulated payload has message.content + thinking + done."""
+    lines = [
+        json.dumps({"message": {"role": "assistant", "content": "Sure, "}}).encode(),
+        json.dumps({"message": {"role": "assistant", "thinking": "planning..."}}).encode(),
+        json.dumps({"message": {"role": "assistant", "content": "here:"}}).encode(),
+        json.dumps({
+            "message":    {"role": "assistant", "content": ""},
+            "done":       True,
+            "done_reason": "stop",
+        }).encode(),
+    ]
+    fake = _FakeClient(lines)
+    monkeypatch.setattr(app_mod.httpx, "AsyncClient", lambda **kw: fake)
+
+    payload = _run(app_mod._stream_and_accumulate(
+        "http://fake:11434", "/api/chat",
+        {"model": "m", "messages": [{"role": "user", "content": "hi"}], "stream": False},
+    ))
+
+    assert payload["message"]["role"] == "assistant"
+    assert payload["message"]["content"] == "Sure, here:"
+    assert payload["message"]["thinking"] == "planning..."
+    assert payload["done"] is True
+    # Caller's stream=False is overridden on the wire.
+    assert fake.stream_calls[0][2]["stream"] is True
+
+
+def test_accumulate_ticks_activity_per_line(app_mod, monkeypatch):
+    """Every non-empty NDJSON line increments the instance card's chunk counter."""
+    lines = [
+        json.dumps({"response": "a"}).encode(),
+        json.dumps({"response": "b"}).encode(),
+        json.dumps({"response": "c"}).encode(),
+        json.dumps({"response": "", "done": True}).encode(),
+    ]
+    fake = _FakeClient(lines)
+    monkeypatch.setattr(app_mod.httpx, "AsyncClient", lambda **kw: fake)
+
+    target = app_mod.config.OLLAMA_0_URL
+    app_mod._activity_set(target, "m", "/api/generate")
+    try:
+        _run(app_mod._stream_and_accumulate(
+            target, "/api/generate", {"model": "m", "prompt": "p"}
+        ))
+        entry = app_mod._activity[app_mod._gpu_label(target)]
+        # 4 non-empty NDJSON lines → chunks == 4.
+        assert entry is not None
+        assert entry["chunks"] == 4
+        # Rolling text buffer fed from the per-line append.
+        assert entry.get("text", "").endswith("abc")
+    finally:
+        app_mod._activity_clear(target)
+
+
+def test_buffered_stream_proxy_returns_json_response(app_mod, monkeypatch):
+    """_buffered_stream_proxy serializes the accumulated dict to a JSON Response."""
+    lines = [
+        json.dumps({"response": "ok"}).encode(),
+        json.dumps({"response": "", "done": True, "done_reason": "stop"}).encode(),
+    ]
+    fake = _FakeClient(lines)
+    monkeypatch.setattr(app_mod.httpx, "AsyncClient", lambda **kw: fake)
+
+    resp = _run(app_mod._buffered_stream_proxy(
+        "http://fake:11434", "/api/generate", {"model": "m", "prompt": "p"}
+    ))
+
+    assert resp.media_type == "application/json"
+    body = json.loads(bytes(resp.body))
+    assert body["response"] == "ok"
+    assert body["done"] is True
+    # _activity_clear ran in finally → card shows idle.
+    assert app_mod._activity[app_mod._gpu_label("http://fake:11434")] is None


### PR DESCRIPTION
Closes #64

## Summary

Make the Ollama Instances card's tok counter tick for callers that send `stream: False` — batch jobs and the lancellmot extractor chat path — by buffer-streaming the Ollama response inside merLLM and returning the single-JSON shape the caller expects. Wire contract to callers is unchanged; only the Ollama-facing request is rewritten.

- New `_stream_and_accumulate(target, path, body) -> dict` in `api/app.py`: forces `stream=True` on the Ollama-facing body, loops over NDJSON lines calling `_activity_inc` + `_activity_append_token` per line (live card updates), accumulates `response` (generate) or `message.content`/`message.thinking` (chat) into the same dict shape a `stream=False` request would have returned.
- New `_buffered_stream_proxy(target, path, body) -> Response` wraps `_activity_set` / `_activity_clear` around the accumulator and serializes the final dict to a single JSON `Response`.
- `_proxy_nonstream` branches on path: `/api/generate` + `/api/chat` → buffered; embeddings/show/pull stay on the existing `_proxy` (no NDJSON to accumulate).
- `queue_manager._run_batch_job_async` swaps `client.post` + `resp.json()` for `_app._stream_and_accumulate`. `_validate_batch_response` is unchanged — accumulated payload has the same `response` / `done_reason` / `prompt_eval_count` fields.

## Why the wire swap is safe

`stream` is wire-format only on the Ollama API — KV cache, `num_ctx`, and `num_predict` are identical in both modes, so there is no ctx/KV cost to flipping it internally. `PROXY_READ_TIMEOUT_SECONDS` and the tick's busy-slot sweep (`SLOT_MAX_WALL_SECONDS=1800`) remain the deadlock guards; the existing `_generate_stream` proves the same pattern against those guards.

## Tests

- 4 new unit tests in `tests/test_buffered_stream.py`:
  - `_stream_and_accumulate` wire shape for `/api/generate` (response concatenation, done/done_reason/prompt_eval_count passthrough, `stream=True` injected on wire).
  - `_stream_and_accumulate` wire shape for `/api/chat` (content + thinking concatenation, caller's `stream: False` overridden on wire).
  - Per-line `_activity_inc` ticks chunks counter; `_activity_append_token` fills rolling text buffer.
  - `_buffered_stream_proxy` returns `application/json` Response and clears the card in `finally`.
- `python3 -m pytest tests/ --ignore=tests/test_integration.py` → **206 passed in 2.25s** (202 prior + 4 new).

## Manual verification to run post-merge (per issue #64 test plan)

**Container rebuild required** (`docker compose up -d --build` — `restart` won't pick up `api/` edits; see memory).

1. Run a batch job. Expect the "tok" counter on the active instance card to increment mid-job instead of staying at 0 for the full duration.
2. Kick a doc through the lancellmot extractor. Same — counter should pulse during the chat call.
3. Existing `stream: True` chat (dashboard chat widget) should be visually unchanged; wire bytes still stream straight to caller via `_stream_proxy`.
4. Existing `tests/test_integration.py:135` (`stream: False` generate through the priority queue) should continue to pass unmodified.

## Out of scope

- No caller-side changes in lancellmot/parsival/etc. Single-JSON contract preserved.
- `stream: True` callers already tick the counter via `_generate_stream` — path unchanged.