### PR TITLE
Add /api/batch/status-by-ids; split Active/Queued in dashboard (#71)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -48,7 +48,7 @@ _req_log = logging.getLogger("merllm.requests")
 log = logging.getLogger("merllm")
 
 import httpx
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, HTTPException
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect, HTTPException, Body
 from fastapi.responses import Response, StreamingResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -946,6 +946,22 @@ async def batch_submit(request: Request):
 @app.get("/api/batch/status")
 async def batch_status_list():
     return db.list_batch_jobs()
+
+
+@app.post("/api/batch/status-by-ids")
+async def batch_status_by_ids(body: dict = Body(...)):
+    """Return status for the given job IDs. Missing IDs are omitted from the
+    response — the client distinguishes 'not yet written' from 'deleted' by
+    consecutive-miss count on its side, not by HTTP error.
+
+    Bypasses the LIMIT 200 window on GET /api/batch/status, so clients with
+    many in-flight jobs don't lose visibility when newer jobs from other
+    sources push theirs past the window.
+    """
+    ids = body.get("ids") or []
+    if not isinstance(ids, list):
+        raise HTTPException(status_code=400, detail="'ids' must be a list")
+    return db.get_batch_jobs_by_ids([str(x) for x in ids])
 
 
 @app.get("/api/batch/status/{job_id}")

--- a/api/db.py
+++ b/api/db.py
@@ -169,6 +169,25 @@ def list_batch_jobs(status: Optional[str] = None, ready_only: bool = False) -> l
     return [dict(r) for r in rows]
 
 
+def get_batch_jobs_by_ids(ids: list[str]) -> list[dict]:
+    """
+    Return batch_jobs rows whose id is in ``ids``. Unknown ids are omitted
+    (caller must detect absence by comparing input to output). Used by clients
+    that track their own in-flight job IDs and need status regardless of how
+    many newer jobs other clients have submitted (bypasses the LIMIT 200
+    window on list_batch_jobs).
+    """
+    if not ids:
+        return []
+    placeholders = ",".join("?" * len(ids))
+    with lock:
+        rows = conn().execute(
+            f"SELECT * FROM batch_jobs WHERE id IN ({placeholders})",
+            tuple(ids)
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
 def get_earliest_retry_after() -> Optional[float]:
     """
     Return the smallest retry_after timestamp among deferred queued jobs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -223,6 +223,35 @@ class TestMerllmFeatures:
         # Clean up: cancel the test job
         post(MERLLM, f"/api/batch/{job_id}/cancel")
 
+    def test_batch_status_by_ids(self):
+        """POST /api/batch/status-by-ids returns known IDs, omits unknowns."""
+        r = post(MERLLM, "/api/batch/submit", json={
+            "source_app": "integration_test",
+            "prompt": "Say hello.",
+            "model": "qwen3:30b-a3b",
+        })
+        assert r.status_code == 200
+        job_id = r.json()["id"]
+
+        bogus = str(uuid.uuid4())
+        r2 = post(MERLLM, "/api/batch/status-by-ids", json={"ids": [job_id, bogus]})
+        assert r2.status_code == 200
+        rows = r2.json()
+        returned = {row["id"] for row in rows}
+        assert job_id in returned
+        assert bogus not in returned
+
+        # Empty list returns empty list, not error.
+        r3 = post(MERLLM, "/api/batch/status-by-ids", json={"ids": []})
+        assert r3.status_code == 200
+        assert r3.json() == []
+
+        # Malformed body rejected.
+        r4 = post(MERLLM, "/api/batch/status-by-ids", json={"ids": "not-a-list"})
+        assert r4.status_code == 400
+
+        post(MERLLM, f"/api/batch/{job_id}/cancel")
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Section 4: Cross-Service — My Day Panel

--- a/web/app.js
+++ b/web/app.js
@@ -128,8 +128,11 @@ function _startActivityStream() {
       // Live queue updates from SSE
       if (a.queue !== undefined) renderQueueTable(a.queue);
       if (a.queue_summary !== undefined) {
-        const qTotal = (a.queue_summary.queued || 0) + (a.queue_summary.running || 0);
-        set("ov-queue", qTotal);
+        // active = running on a GPU right now; queued = waiting in merLLM's
+        // SQLite-backed queue. Keep the two numbers distinct so the user
+        // can see queue depth even when the GPUs are saturated.
+        const qs = a.queue_summary;
+        set("ov-queue", `${qs.running || 0} / ${qs.queued || 0}`);
       }
     } catch (_) {}
   };
@@ -281,8 +284,7 @@ function renderOverview(s) {
   renderSchedulerStatus(s.scheduler_status);
   set("ov-default-model", s.default_model || "—");
   const q = s.queue || {};
-  const qTotal = (q.queued || 0) + (q.running || 0);
-  set("ov-queue", s.queue ? qTotal : "—");
+  set("ov-queue", s.queue ? `${q.running || 0} / ${q.queued || 0}` : "—");
 
   // Pending model change
   const pendingRow = document.getElementById("ov-pending-model-row");

--- a/web/index.html
+++ b/web/index.html
@@ -64,7 +64,7 @@
           <span id="ov-pending-model" class="stat-value" style="color:var(--yellow)">—</span>
         </div>
         <div class="stat-row">
-          <span class="stat-label">In flight</span>
+          <span class="stat-label">Active / Queued</span>
           <span id="ov-queue" class="stat-value">—</span>
         </div>
         <div id="gpu-router-cards"></div>


### PR DESCRIPTION
## Summary
- New `POST /api/batch/status-by-ids` — returns rows for an explicit ID list via `WHERE id IN (?, ?, ...)`, bypassing the 200-row LIMIT on `GET /api/batch/status`. Missing IDs are omitted from the response; clients detect loss by consecutive-miss count, not HTTP error.
- Dashboard "In flight" counter split into "Active / Queued" so a 2/435 backlog is visually distinct from a quiet 2/0 system.

## Why
Clients with many in-flight jobs (lancellmot extract fan-out, parsival reanalyze) lose visibility of their own jobs when newer traffic from another source pushes them past the 200-row window. The default GET endpoint was built for a human browsing recent history — it's the wrong shape for a poller that already knows its ID set.

## Test plan
- [x] `tests/test_integration.py::TestMerllmFeatures::test_batch_status_by_ids` passes against the live container
  - returns known IDs, omits unknown IDs
  - empty list returns `[]`
  - non-list body rejected with 400
- [x] Rebuilt container; `/api/merllm/status` healthy; both GPUs draining work under new endpoint
- [x] Dashboard at /web/ shows "Active / Queued" row with live values

## Downstream
- Consumed by lancellmot#48 (merges after this)
- Parsival batch poller could migrate to this in a follow-up (#80 kept narrow)